### PR TITLE
Update obsolete package srclpage2

### DIFF
--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -83,7 +83,7 @@
 
 %%%
 % fancyheadings (nicht nur) fuer koma
-\usepackage[automark]{scrpage2}
+\usepackage[automark]{scrlayer-scrpage}
 %
 %%%
 


### PR DESCRIPTION
srclpage is obsolete and miktex doesn't support it any more so it is not possible to build the template.
scrlayer-scrpage the alternative recommended from pdflatex.
It's tested and working